### PR TITLE
Drop check for weak default TLS TLS ciphers [PLAT-27727]

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -41,64 +41,6 @@ module RestClient
       new(args).execute(& block)
     end
 
-    # This is similar to the list now in ruby core, but adds HIGH and RC4-MD5
-    # for better compatibility (similar to Firefox) and moves AES-GCM cipher
-    # suites above DHE/ECDHE CBC suites (similar to Chromium).
-    # https://github.com/ruby/ruby/commit/699b209cf8cf11809620e12985ad33ae33b119ee
-    #
-    # This list will be used by default if the Ruby global OpenSSL default
-    # ciphers appear to be a weak list.
-    DefaultCiphers = %w{
-      !aNULL
-      !eNULL
-      !EXPORT
-      !SSLV2
-      !LOW
-
-      ECDHE-ECDSA-AES128-GCM-SHA256
-      ECDHE-RSA-AES128-GCM-SHA256
-      ECDHE-ECDSA-AES256-GCM-SHA384
-      ECDHE-RSA-AES256-GCM-SHA384
-      DHE-RSA-AES128-GCM-SHA256
-      DHE-DSS-AES128-GCM-SHA256
-      DHE-RSA-AES256-GCM-SHA384
-      DHE-DSS-AES256-GCM-SHA384
-      AES128-GCM-SHA256
-      AES256-GCM-SHA384
-      ECDHE-ECDSA-AES128-SHA256
-      ECDHE-RSA-AES128-SHA256
-      ECDHE-ECDSA-AES128-SHA
-      ECDHE-RSA-AES128-SHA
-      ECDHE-ECDSA-AES256-SHA384
-      ECDHE-RSA-AES256-SHA384
-      ECDHE-ECDSA-AES256-SHA
-      ECDHE-RSA-AES256-SHA
-      DHE-RSA-AES128-SHA256
-      DHE-RSA-AES256-SHA256
-      DHE-RSA-AES128-SHA
-      DHE-RSA-AES256-SHA
-      DHE-DSS-AES128-SHA256
-      DHE-DSS-AES256-SHA256
-      DHE-DSS-AES128-SHA
-      DHE-DSS-AES256-SHA
-      AES128-SHA256
-      AES256-SHA256
-      AES128-SHA
-      AES256-SHA
-      ECDHE-ECDSA-RC4-SHA
-      ECDHE-RSA-RC4-SHA
-      RC4-SHA
-
-      HIGH
-      +RC4
-      RC4-MD5
-    }.join(":")
-
-    # A set of weak default ciphers that we will override by default.
-    WeakDefaultCiphers = Set.new([
-      "ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW",
-    ])
-
     SSLOptionList = %w{client_cert client_key ca_file ca_path cert_store
                        version ciphers verify_callback verify_callback_warnings}
 
@@ -154,15 +96,6 @@ module RestClient
       # If there's no CA file, CA path, or cert store provided, use default
       if !ssl_ca_file && !ssl_ca_path && !@ssl_opts.include?(:cert_store)
         @ssl_opts[:cert_store] = self.class.default_ssl_cert_store
-      end
-
-      unless @ssl_opts.include?(:ciphers)
-        # If we're on a Ruby version that has insecure default ciphers,
-        # override it with our default list.
-        if WeakDefaultCiphers.include?(
-             OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.fetch(:ciphers))
-          @ssl_opts[:ciphers] = DefaultCiphers
-        end
       end
 
       @tf = nil # If you are a raw request, this is your tempfile

--- a/lib/restclient/version.rb
+++ b/lib/restclient/version.rb
@@ -1,5 +1,5 @@
 module RestClient
-  VERSION = '1.8.0' unless defined?(self::VERSION)
+  VERSION = '1.8.1' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/rest-client/rest-client'
   s.summary = 'Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.'
 
-  s.add_development_dependency('webmock', '~> 1.4')
+  s.add_development_dependency('webmock', '~> 2.3.2')
   s.add_development_dependency('rspec', '~> 2.4')
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-doc')

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -627,56 +627,6 @@ describe RestClient::Request do
       @request.transmit(@uri, 'req', 'payload')
     end
 
-    it "should override ssl_ciphers with better defaults with weak default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW",
-          :options=>-2147480577,
-        }
-      )
-
-      @request = RestClient::Request.new(
-        :method => :put,
-        :url => 'https://some/resource',
-        :payload => 'payload',
-      )
-
-      @net.should_receive(:ciphers=).with(RestClient::Request::DefaultCiphers)
-
-      @http.stub(:request)
-      @request.stub(:process_result)
-      @request.stub(:response_log)
-      @request.transmit(@uri, 'req', 'payload')
-    end
-
-    it "should not override ssl_ciphers with better defaults with different default ciphers" do
-      stub_const(
-        '::OpenSSL::SSL::SSLContext::DEFAULT_PARAMS',
-        {
-          :ssl_version=>"SSLv23",
-          :verify_mode=>1,
-          :ciphers=>"HIGH:!aNULL:!eNULL:!EXPORT:!LOW:!MEDIUM:!SSLv2",
-          :options=>-2147480577,
-        }
-      )
-
-      @request = RestClient::Request.new(
-        :method => :put,
-        :url => 'https://some/resource',
-        :payload => 'payload',
-      )
-
-      @net.should_not_receive(:ciphers=)
-
-      @http.stub(:request)
-      @request.stub(:process_result)
-      @request.stub(:response_log)
-      @request.transmit(@uri, 'req', 'payload')
-    end
-
     it "should set the ssl_client_cert if provided" do
       @request = RestClient::Request.new(
               :method => :put,

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -85,8 +85,8 @@ describe RestClient::Response do
     end
 
     it "follows a redirection and keep the parameters" do
-      stub_request(:get, 'http://foo:bar@some/resource').with(:headers => {'Accept' => 'application/json'}).to_return(:body => '', :status => 301, :headers => {'Location' => 'http://new/resource'})
-      stub_request(:get, 'http://foo:bar@new/resource').with(:headers => {'Accept' => 'application/json'}).to_return(:body => 'Foo')
+      stub_request(:get, 'http://some/resource').with(:basic_auth => ['foo', 'bar'], :headers => {'Accept' => 'application/json'}).to_return(:body => '', :status => 301, :headers => {'Location' => 'http://new/resource'})
+      stub_request(:get, 'http://new/resource').with(:basic_auth => ['foo', 'bar'], :headers => {'Accept' => 'application/json'}).to_return(:body => 'Foo')
       RestClient::Request.execute(:url => 'http://some/resource', :method => :get, :user => 'foo', :password => 'bar', :headers => {:accept => :json}).body.should eq 'Foo'
     end
 


### PR DESCRIPTION
This is a manual cherry-picking of https://github.com/rest-client/rest-client/pull/573.

The `:ciphers` property is no longer set on `DEFAULT_PARAMS` if OpenSSL is at least at version 1.1.0. This issue was surfaced when upgrading from Ruby 2.2 to 2.5.

I've bumped the web-mock version to get most of the specs passing, but I still have one failure related to this. I'm also getting two spec failures locally that seem to be totally unrelated to this change, because I also get them on the v1.8.0 tag running under Ruby 2.2.4.